### PR TITLE
fix: native Crash when some js error occur, #20

### DIFF
--- a/app-seed/package.json
+++ b/app-seed/package.json
@@ -23,7 +23,7 @@
     "minimist": "1.2.0",
     "moment": "2.23.0",
     "react": "16.0.0",
-    "react-native": "https://github.com/UnPourTous/react-native.git#release/0.51.8",
+    "react-native": "https://github.com/UnPourTous/react-native.git#release/0.51.10",
     "react-native-cookies": "3.3.0",
     "react-navigation-redux-helpers": "1.0.1",
     "react-redux": "5.0.6",

--- a/libraryDev/package.json
+++ b/libraryDev/package.json
@@ -26,7 +26,7 @@
     "moment": "2.23.0",
     "qs": "^6.9.1",
     "react": "16.0.0",
-    "react-native": "https://github.com/UnPourTous/react-native.git#release/0.51.8",
+    "react-native": "https://github.com/UnPourTous/react-native.git#release/0.51.10",
     "react-native-cookies": "3.3.0",
     "react-native-json-tree": "^1.2.0",
     "react-navigation-redux-helpers": "1.0.1",


### PR DESCRIPTION
1. 更新RN的patch版本，修复 #20 ，具体修复见 https://github.com/UnPourTous/react-native/commit/9d45511e8909b22411edfdcc42a4370443a2c9ff