### PR TITLE
feat: traversal tool supports tab templates

### DIFF
--- a/app-seed/src/modules/example-tab/TabContainerScene/TabContainerScene.js
+++ b/app-seed/src/modules/example-tab/TabContainerScene/TabContainerScene.js
@@ -10,9 +10,10 @@ import {
   ModuleManager,
   createModuleConnect,
   createSceneConnect,
-  Theme
+  Theme,
+  WeDrawerNavigator
 } from '@webank/trident'
-import { TabNavigator, DrawerNavigator, TabBarBottom } from '@unpourtous/react-navigation'
+import { TabNavigator, TabBarBottom } from '@unpourtous/react-navigation'
 import ModulePrivate from '../'
 import HomeTab from './tabs/HomeTab'
 import SettingTab from './tabs/SettingTab'
@@ -54,7 +55,7 @@ export default class TabContainerScene extends WeBaseScene {
       initialRouteName: this.params.initialTab
     })
 
-    this.MyDrawerNavigator = new DrawerNavigator(
+    this.MyDrawerNavigator = new WeDrawerNavigator(
       {
         TabContainer: MyTabNavigator,
         TabContainer2: MyTabNavigator

--- a/library/index.js
+++ b/library/index.js
@@ -1,5 +1,6 @@
 import TridentApp from './TridentApp'
 import AppNavigator from './navigation/AppNavigator'
+import WeDrawerNavigator from './navigation/react-navigation-ext/WeDrawerNavigator'
 import WeBaseScene from './base/WeBaseScene'
 import TridentStat from './statistics/TridentStat'
 import RNEnv from './utils/RNEnv'
@@ -12,6 +13,8 @@ export {
   TridentApp,
 
   AppNavigator,
+
+  WeDrawerNavigator,
 
   WeBaseScene,
 

--- a/library/navigation/react-navigation-ext/WeDrawerNavigator.js
+++ b/library/navigation/react-navigation-ext/WeDrawerNavigator.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { DrawerNavigator } from '@unpourtous/react-navigation'
+import SceneTraversal from '@webank/trident/library/qualityTools/SceneTraversal'
+
+export default (routeConfigs, config) => {
+  class WeDrawerNavigator extends React.Component {
+    drawer = new DrawerNavigator(
+      routeConfigs,
+      config
+    )
+
+    render () {
+      const Drawer = this.drawer
+      return <Drawer {...this.props}
+        ref={ref => {
+          ref && (this.navigation = ref._navigation)
+        }}
+        onNavigationStateChange={(state, nextState, action) => {
+          this.props.onNavigationStateChange && this.props.onNavigationStateChange(state, nextState, action)
+          // Traversal
+          if (action && action.type === 'Navigation/NAVIGATE' && action.routeName === 'DrawerOpen') {
+            SceneTraversal.onDrawerOpen(this.navigation)
+          }
+        }} />
+    }
+  }
+
+  return WeDrawerNavigator
+}


### PR DESCRIPTION
[All][traversal] add support for tab templates. Group elements by tabs and traverse them in order.
Also when drawer is opened, the tool would close it in order to avoid interrupting traversal.